### PR TITLE
2.8.24 hash.

### DIFF
--- a/README
+++ b/README
@@ -67,3 +67,4 @@ hash redis-3.2.9.tar.gz sha256 6eaacfa983b287e440d0839ead20c2231749d5d6b78bbe0e0
 hash redis-4.0.0.tar.gz sha256 d539ae309295721d5c3ed7298939645b6f86ab5d25fdf2a0352ab575c159df2d http://download.redis.io/releases/redis-4.0.0.tar.gz
 hash redis-4.0.1.tar.gz sha256 2049cd6ae9167f258705081a6ef23bb80b7eff9ff3d0d7481e89510f27457591 http://download.redis.io/releases/redis-4.0.1.tar.gz
 hash redis-3.2.10.tar.gz sha256 411c604a716104f7f5a326abfad32de9cea10f15f987bec45cf86f315e9e63a0 http://download.redis.io/releases/redis-3.2.10.tar.gz
+hash redis-2.8.24.tar.gz sha256 6c86ca5291ca7f4e37d9c90511eed67beb6649befe57e2e26307f74adb8630fe http://download.redis.io/releases/redis-2.8.24.tar.gz


### PR DESCRIPTION
I computed this hash by downloading the 2.8.24 release.  However, only @antirez can truly verify the correctness of this hash.

Fixes #3.